### PR TITLE
chore(tendermint): refactor CLI to encapsulate global state

### DIFF
--- a/cmd/tendermint/commands/debug/debug.go
+++ b/cmd/tendermint/commands/debug/debug.go
@@ -1,41 +1,44 @@
 package debug
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
 
-var (
+func Cmd(logger log.Logger) *cobra.Command {
+	b := builder{
+		logger: logger,
+	}
+	return b.cmd()
+}
+
+type builder struct {
+	logger log.Logger
+
 	nodeRPCAddr string
 	profAddr    string
 	frequency   uint
-
-	flagNodeRPCAddr = "rpc-laddr"
-	flagProfAddr    = "pprof-laddr"
-	flagFrequency   = "frequency"
-
-	logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
-)
-
-// DebugCmd defines the root command containing subcommands that assist in
-// debugging running Tendermint processes.
-var DebugCmd = &cobra.Command{
-	Use:   "debug",
-	Short: "A utility to kill or watch a Tendermint process while aggregating debugging data",
 }
 
-func init() {
-	DebugCmd.PersistentFlags().SortFlags = true
-	DebugCmd.PersistentFlags().StringVar(
-		&nodeRPCAddr,
-		flagNodeRPCAddr,
+func (b *builder) cmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "debug",
+		Short: "A utility to kill or watch a Tendermint process while aggregating debugging data",
+	}
+
+	cmd.PersistentFlags().SortFlags = true
+	cmd.PersistentFlags().StringVar(
+		&b.nodeRPCAddr,
+		"rpc-laddr",
 		"tcp://localhost:26657",
 		"the Tendermint node's RPC address (<host>:<port>)",
 	)
 
-	DebugCmd.AddCommand(killCmd)
-	DebugCmd.AddCommand(dumpCmd)
+	cmd.AddCommand(
+		b.killCmd(),
+		b.dumpCmd(),
+	)
+
+	return &cmd
 }

--- a/cmd/tendermint/commands/gen_node_key.go
+++ b/cmd/tendermint/commands/gen_node_key.go
@@ -9,26 +9,26 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// GenNodeKeyCmd allows the generation of a node key. It prints node's ID to
-// the standard output.
-var GenNodeKeyCmd = &cobra.Command{
-	Use:     "gen-node-key",
-	Aliases: []string{"gen_node_key"},
-	Short:   "Generate a node key for this node and print its ID",
-	PreRun:  deprecateSnakeCase,
-	RunE:    genNodeKey,
-}
+func (b *builderRoot) genNodeCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "gen-node-key",
+		Aliases: []string{"gen_node_key"},
+		Short:   "Generate a node key for this node and print its ID",
+		PreRun:  deprecateSnakeCase,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeKeyFile := b.cfg.NodeKeyFile()
+			if tmos.FileExists(nodeKeyFile) {
+				return fmt.Errorf("node key at %s already exists", nodeKeyFile)
+			}
 
-func genNodeKey(cmd *cobra.Command, args []string) error {
-	nodeKeyFile := config.NodeKeyFile()
-	if tmos.FileExists(nodeKeyFile) {
-		return fmt.Errorf("node key at %s already exists", nodeKeyFile)
+			nodeKey, err := p2p.LoadOrGenNodeKey(nodeKeyFile)
+			if err != nil {
+				return err
+			}
+			fmt.Println(nodeKey.ID())
+			return nil
+		},
 	}
 
-	nodeKey, err := p2p.LoadOrGenNodeKey(nodeKeyFile)
-	if err != nil {
-		return err
-	}
-	fmt.Println(nodeKey.ID())
-	return nil
+	return &cmd
 }

--- a/cmd/tendermint/commands/gen_validator.go
+++ b/cmd/tendermint/commands/gen_validator.go
@@ -9,22 +9,24 @@ import (
 	"github.com/tendermint/tendermint/privval"
 )
 
-// GenValidatorCmd allows the generation of a keypair for a
-// validator.
-var GenValidatorCmd = &cobra.Command{
-	Use:     "gen-validator",
-	Aliases: []string{"gen_validator"},
-	Short:   "Generate new validator keypair",
-	PreRun:  deprecateSnakeCase,
-	Run:     genValidator,
+func (b *builderRoot) genValidatorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "gen-validator",
+		Aliases: []string{"gen_validator"},
+		Short:   "Generate new validator keypair",
+		PreRun:  deprecateSnakeCase,
+		RunE:    genValidator,
+	}
 }
 
-func genValidator(cmd *cobra.Command, args []string) {
+func genValidator(cmd *cobra.Command, args []string) error {
 	pv := privval.GenFilePV("", "")
 	jsbz, err := tmjson.Marshal(pv)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf(`%v
+
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), `%v
 `, string(jsbz))
+	return err
 }

--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/p2p"
@@ -14,18 +15,17 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
-// InitFilesCmd initialises a fresh Tendermint Core instance.
-var InitFilesCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize Tendermint",
-	RunE:  initFiles,
+func (b *builderRoot) initCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize Tendermint",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return initFilesWithConfig(b.cfg, b.logger)
+		},
+	}
 }
 
-func initFiles(cmd *cobra.Command, args []string) error {
-	return initFilesWithConfig(config)
-}
-
-func initFilesWithConfig(config *cfg.Config) error {
+func initFilesWithConfig(config *cfg.Config, logger log.Logger) error {
 	// private validator
 	privValKeyFile := config.PrivValidatorKeyFile()
 	privValStateFile := config.PrivValidatorStateFile()

--- a/cmd/tendermint/commands/probe_upnp.go
+++ b/cmd/tendermint/commands/probe_upnp.go
@@ -9,17 +9,19 @@ import (
 	"github.com/tendermint/tendermint/p2p/upnp"
 )
 
-// ProbeUpnpCmd adds capabilities to test the UPnP functionality.
-var ProbeUpnpCmd = &cobra.Command{
-	Use:     "probe-upnp",
-	Aliases: []string{"probe_upnp"},
-	Short:   "Test UPnP functionality",
-	RunE:    probeUpnp,
-	PreRun:  deprecateSnakeCase,
+// probeUpnpCmd adds capabilities to test the UPnP functionality.
+func (b *builderRoot) probeUpnpCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "probe-upnp",
+		Aliases: []string{"probe_upnp"},
+		Short:   "Test UPnP functionality",
+		RunE:    b.probeUpnp,
+		PreRun:  deprecateSnakeCase,
+	}
 }
 
-func probeUpnp(cmd *cobra.Command, args []string) error {
-	capabilities, err := upnp.Probe(logger)
+func (b *builderRoot) probeUpnp(cmd *cobra.Command, args []string) error {
+	capabilities, err := upnp.Probe(b.logger)
 	if err != nil {
 		fmt.Println("Probe failed: ", err)
 	} else {

--- a/cmd/tendermint/commands/replay.go
+++ b/cmd/tendermint/commands/replay.go
@@ -6,23 +6,30 @@ import (
 	"github.com/tendermint/tendermint/consensus"
 )
 
-// ReplayCmd allows replaying of messages from the WAL.
-var ReplayCmd = &cobra.Command{
-	Use:   "replay",
-	Short: "Replay messages from WAL",
-	Run: func(cmd *cobra.Command, args []string) {
-		consensus.RunReplayFile(config.BaseConfig, config.Consensus, false)
-	},
+func (b *builderRoot) replayCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "replay",
+		Short: "Replay messages from WAL",
+		Run: func(cmd *cobra.Command, args []string) {
+			consensus.RunReplayFile(b.cfg.BaseConfig, b.cfg.Consensus, false)
+		},
+	}
+
+	return &cmd
 }
 
 // ReplayConsoleCmd allows replaying of messages from the WAL in a
 // console.
-var ReplayConsoleCmd = &cobra.Command{
-	Use:     "replay-console",
-	Aliases: []string{"replay_console"},
-	Short:   "Replay messages from WAL in a console",
-	Run: func(cmd *cobra.Command, args []string) {
-		consensus.RunReplayFile(config.BaseConfig, config.Consensus, true)
-	},
-	PreRun: deprecateSnakeCase,
+func (b *builderRoot) replayConsoleCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "replay-console",
+		Aliases: []string{"replay_console"},
+		Short:   "Replay messages from WAL in a console",
+		Run: func(cmd *cobra.Command, args []string) {
+			consensus.RunReplayFile(b.cfg.BaseConfig, b.cfg.Consensus, true)
+		},
+		PreRun: deprecateSnakeCase,
+	}
+
+	return &cmd
 }

--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -12,10 +12,11 @@ import (
 	"github.com/tendermint/tendermint/store"
 )
 
-var RollbackStateCmd = &cobra.Command{
-	Use:   "rollback",
-	Short: "rollback tendermint state by one height",
-	Long: `
+func (b *builderRoot) roolbackStateCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "rollback",
+		Short: "rollback tendermint state by one height",
+		Long: `
 A state rollback is performed to recover from an incorrect application state transition,
 when Tendermint has persisted an incorrect app hash and is thus unable to make
 progress. Rollback overwrites a state at height n with the state at height n - 1.
@@ -23,15 +24,18 @@ The application should also roll back to height n - 1. No blocks are removed, so
 restarting Tendermint the transactions in block n will be re-executed against the
 application.
 `,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		height, hash, err := RollbackState(config)
-		if err != nil {
-			return fmt.Errorf("failed to rollback state: %w", err)
-		}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			height, hash, err := RollbackState(b.cfg)
+			if err != nil {
+				return fmt.Errorf("failed to rollback state: %w", err)
+			}
 
-		fmt.Printf("Rolled back state to height %d and hash %v", height, hash)
-		return nil
-	},
+			fmt.Printf("Rolled back state to height %d and hash %v", height, hash)
+			return nil
+		},
+	}
+
+	return &cmd
 }
 
 // RollbackState takes the state at the current height n and overwrites it with the state

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -3,33 +3,122 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	tmflags "github.com/tendermint/tendermint/libs/cli/flags"
 	"github.com/tendermint/tendermint/libs/log"
+	nm "github.com/tendermint/tendermint/node"
 )
 
-var (
-	config = cfg.DefaultConfig()
-	logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
-)
-
-func init() {
-	registerFlagsRootCmd(RootCmd)
+// WithNodeFunc provides a hook to change the node fn for users wishing to:
+//	* Use an external signer for their validators
+//	* Supply an in-proc abci app
+//	* Supply a genesis doc file from another source
+//	* Provide their own DB implementation
+// can copy this file and use something other than the DefaultNewNode function
+func WithNodeFunc(nodeFn nm.Provider) func(*builderRoot) {
+	return func(root *builderRoot) {
+		root.nodeFunc = nodeFn
+	}
 }
 
-func registerFlagsRootCmd(cmd *cobra.Command) {
-	cmd.PersistentFlags().String("log_level", config.LogLevel, "log level")
+// Cmd provides a full tendermint executable.
+func Cmd(opts ...func(*builderRoot)) cli.Executor {
+	b := builderRoot{
+		cfg:      cfg.DefaultConfig(),
+		logger:   log.NewTMLogger(log.NewSyncWriter(os.Stdout)),
+		nodeFunc: nm.DefaultNewNode,
+	}
+	for _, o := range opts {
+		o(&b)
+	}
+
+	defaultHome := os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir))
+	return cli.PrepareBaseCmd(b.cmd(), "TM", defaultHome)
 }
 
-// ParseConfig retrieves the default environment configuration,
+type builderRoot struct {
+	cfg    *cfg.Config
+	logger log.Logger
+
+	nodeFunc nm.Provider
+}
+
+func (b *builderRoot) cmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "tendermint",
+		Short: "BFT state machine replication for applications in any programming languages",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			if cmd.Name() == versionCmdName {
+				return nil
+			}
+
+			config, err := parseConfig()
+			if err != nil {
+				return err
+			}
+			b.cfg = config
+
+			if config.LogFormat == cfg.LogFormatJSON {
+				b.logger = log.NewTMJSONLogger(log.NewSyncWriter(os.Stdout))
+			}
+
+			b.logger, err = tmflags.ParseLogLevel(b.cfg.LogLevel, b.logger, cfg.DefaultLogLevel)
+			if err != nil {
+				return err
+			}
+
+			if viper.GetBool(cli.TraceFlag) {
+				b.logger = log.NewTracingLogger(b.logger)
+			}
+
+			b.logger = b.logger.With("module", "main")
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().String("log_level", b.cfg.LogLevel, "log level")
+
+	cmd.AddCommand(
+		cli.NewCompletionCmd(&cmd, true),
+		debug.Cmd(b.logger),
+		b.genNodeCmd(),
+		b.genValidatorCmd(),
+		b.initCmd(),
+		b.lightCmd(),
+		b.nodeCmd(),
+		b.probeUpnpCmd(),
+		b.replayCmd(),
+		b.replayConsoleCmd(),
+		b.resetCmd(),
+		b.resetPrivValidatorCmd(),
+		b.roolbackStateCmd(),
+		b.showNodeCmd(),
+		b.showValidatorCmd(),
+		b.testnetCmd(),
+		b.versionCmd(),
+	)
+
+	return &cmd
+}
+
+// deprecateSnakeCase is a util function for 0.34.1. Should be removed in 0.35
+func deprecateSnakeCase(cmd *cobra.Command, args []string) {
+	if strings.Contains(cmd.CalledAs(), "_") {
+		fmt.Println("Deprecated: snake_case commands will be replaced by hyphen-case commands in the next major release")
+	}
+}
+
+// parseConfig retrieves the default environment configuration,
 // sets up the Tendermint root and ensures that the root exists
-func ParseConfig() (*cfg.Config, error) {
+func parseConfig() (*cfg.Config, error) {
 	conf := cfg.DefaultConfig()
 	err := viper.Unmarshal(conf)
 	if err != nil {
@@ -41,43 +130,4 @@ func ParseConfig() (*cfg.Config, error) {
 		return nil, fmt.Errorf("error in config file: %v", err)
 	}
 	return conf, nil
-}
-
-// RootCmd is the root command for Tendermint core.
-var RootCmd = &cobra.Command{
-	Use:   "tendermint",
-	Short: "BFT state machine replication for applications in any programming languages",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		if cmd.Name() == VersionCmd.Name() {
-			return nil
-		}
-
-		config, err = ParseConfig()
-		if err != nil {
-			return err
-		}
-
-		if config.LogFormat == cfg.LogFormatJSON {
-			logger = log.NewTMJSONLogger(log.NewSyncWriter(os.Stdout))
-		}
-
-		logger, err = tmflags.ParseLogLevel(config.LogLevel, logger, cfg.DefaultLogLevel)
-		if err != nil {
-			return err
-		}
-
-		if viper.GetBool(cli.TraceFlag) {
-			logger = log.NewTracingLogger(logger)
-		}
-
-		logger = logger.With("module", "main")
-		return nil
-	},
-}
-
-// deprecateSnakeCase is a util function for 0.34.1. Should be removed in 0.35
-func deprecateSnakeCase(cmd *cobra.Command, args []string) {
-	if strings.Contains(cmd.CalledAs(), "_") {
-		fmt.Println("Deprecated: snake_case commands will be replaced by hyphen-case commands in the next major release")
-	}
 }

--- a/cmd/tendermint/commands/show_node_id.go
+++ b/cmd/tendermint/commands/show_node_id.go
@@ -8,21 +8,22 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// ShowNodeIDCmd dumps node's ID to the standard output.
-var ShowNodeIDCmd = &cobra.Command{
-	Use:     "show-node-id",
-	Aliases: []string{"show_node_id"},
-	Short:   "Show this node's ID",
-	RunE:    showNodeID,
-	PreRun:  deprecateSnakeCase,
-}
+func (b *builderRoot) showNodeCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "show-node-id",
+		Aliases: []string{"show_node_id"},
+		Short:   "Show this node's ID",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeKey, err := p2p.LoadNodeKey(b.cfg.NodeKeyFile())
+			if err != nil {
+				return err
+			}
 
-func showNodeID(cmd *cobra.Command, args []string) error {
-	nodeKey, err := p2p.LoadNodeKey(config.NodeKeyFile())
-	if err != nil {
-		return err
+			fmt.Println(nodeKey.ID())
+			return nil
+		},
+		PreRun: deprecateSnakeCase,
 	}
 
-	fmt.Println(nodeKey.ID())
-	return nil
+	return &cmd
 }

--- a/cmd/tendermint/commands/show_validator.go
+++ b/cmd/tendermint/commands/show_validator.go
@@ -5,38 +5,44 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tendermint/tendermint/config"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/privval"
 )
 
-// ShowValidatorCmd adds capabilities for showing the validator info.
-var ShowValidatorCmd = &cobra.Command{
-	Use:     "show-validator",
-	Aliases: []string{"show_validator"},
-	Short:   "Show this node's validator info",
-	RunE:    showValidator,
-	PreRun:  deprecateSnakeCase,
+func (b *builderRoot) showValidatorCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:     "show-validator",
+		Aliases: []string{"show_validator"},
+		Short:   "Show this node's validator info",
+		RunE:    showValidatorGen(b.cfg),
+		PreRun:  deprecateSnakeCase,
+	}
+
+	return &cmd
 }
 
-func showValidator(cmd *cobra.Command, args []string) error {
-	keyFilePath := config.PrivValidatorKeyFile()
-	if !tmos.FileExists(keyFilePath) {
-		return fmt.Errorf("private validator file %s does not exist", keyFilePath)
+func showValidatorGen(cfg *config.Config) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		keyFilePath := cfg.PrivValidatorKeyFile()
+		if !tmos.FileExists(keyFilePath) {
+			return fmt.Errorf("private validator file %s does not exist", keyFilePath)
+		}
+
+		pv := privval.LoadFilePV(keyFilePath, cfg.PrivValidatorStateFile())
+
+		pubKey, err := pv.GetPubKey()
+		if err != nil {
+			return fmt.Errorf("can't get pubkey: %w", err)
+		}
+
+		bz, err := tmjson.Marshal(pubKey)
+		if err != nil {
+			return fmt.Errorf("failed to marshal private validator pubkey: %w", err)
+		}
+
+		fmt.Println(string(bz))
+		return nil
 	}
-
-	pv := privval.LoadFilePV(keyFilePath, config.PrivValidatorStateFile())
-
-	pubKey, err := pv.GetPubKey()
-	if err != nil {
-		return fmt.Errorf("can't get pubkey: %w", err)
-	}
-
-	bz, err := tmjson.Marshal(pubKey)
-	if err != nil {
-		return fmt.Errorf("failed to marshal private validator pubkey: %w", err)
-	}
-
-	fmt.Println(string(bz))
-	return nil
 }

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -12,6 +12,7 @@ import (
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/libs/log"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
@@ -19,7 +20,18 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
-var (
+const (
+	nodeDirPerm = 0755
+)
+
+func (b *builderRoot) testnetCmd() *cobra.Command {
+	bt := builderTestnet{logger: b.logger}
+	return bt.cmd()
+}
+
+type builderTestnet struct {
+	logger log.Logger
+
 	nValidators    int
 	nNonValidators int
 	initialHeight  int64
@@ -34,53 +46,13 @@ var (
 	hostnames               []string
 	p2pPort                 int
 	randomMonikers          bool
-)
-
-const (
-	nodeDirPerm = 0755
-)
-
-func init() {
-	TestnetFilesCmd.Flags().IntVar(&nValidators, "v", 4,
-		"number of validators to initialize the testnet with")
-	TestnetFilesCmd.Flags().StringVar(&configFile, "config", "",
-		"config file to use (note some options may be overwritten)")
-	TestnetFilesCmd.Flags().IntVar(&nNonValidators, "n", 0,
-		"number of non-validators to initialize the testnet with")
-	TestnetFilesCmd.Flags().StringVar(&outputDir, "o", "./mytestnet",
-		"directory to store initialization data for the testnet")
-	TestnetFilesCmd.Flags().StringVar(&nodeDirPrefix, "node-dir-prefix", "node",
-		"prefix the directory name for each node with (node results in node0, node1, ...)")
-	TestnetFilesCmd.Flags().Int64Var(&initialHeight, "initial-height", 0,
-		"initial height of the first block")
-
-	TestnetFilesCmd.Flags().BoolVar(&populatePersistentPeers, "populate-persistent-peers", true,
-		"update config of each node with the list of persistent peers build using either"+
-			" hostname-prefix or"+
-			" starting-ip-address")
-	TestnetFilesCmd.Flags().StringVar(&hostnamePrefix, "hostname-prefix", "node",
-		"hostname prefix (\"node\" results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
-	TestnetFilesCmd.Flags().StringVar(&hostnameSuffix, "hostname-suffix", "",
-		"hostname suffix ("+
-			"\".xyz.com\""+
-			" results in persistent peers list ID0@node0.xyz.com:26656, ID1@node1.xyz.com:26656, ...)")
-	TestnetFilesCmd.Flags().StringVar(&startingIPAddress, "starting-ip-address", "",
-		"starting IP address ("+
-			"\"192.168.0.1\""+
-			" results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
-	TestnetFilesCmd.Flags().StringArrayVar(&hostnames, "hostname", []string{},
-		"manually override all hostnames of validators and non-validators (use --hostname multiple times for multiple hosts)")
-	TestnetFilesCmd.Flags().IntVar(&p2pPort, "p2p-port", 26656,
-		"P2P Port")
-	TestnetFilesCmd.Flags().BoolVar(&randomMonikers, "random-monikers", false,
-		"randomize the moniker for each generated node")
 }
 
-// TestnetFilesCmd allows initialisation of files for a Tendermint testnet.
-var TestnetFilesCmd = &cobra.Command{
-	Use:   "testnet",
-	Short: "Initialize files for a Tendermint testnet",
-	Long: `testnet will create "v" + "n" number of directories and populate each with
+func (b *builderTestnet) cmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "testnet",
+		Short: "Initialize files for a Tendermint testnet",
+		Long: `testnet will create "v" + "n" number of directories and populate each with
 necessary files (private validator, genesis, config, etc.).
 
 Note, strict routability for addresses is turned off in the config file.
@@ -91,22 +63,58 @@ Example:
 
 	tendermint testnet --v 4 --o ./output --populate-persistent-peers --starting-ip-address 192.168.10.2
 	`,
-	RunE: testnetFiles,
+		RunE: b.testnetFiles,
+	}
+	cmd.Flags().IntVar(&b.nValidators, "v", 4,
+		"number of validators to initialize the testnet with")
+	cmd.Flags().StringVar(&b.configFile, "config", "",
+		"config file to use (note some options may be overwritten)")
+	cmd.Flags().IntVar(&b.nNonValidators, "n", 0,
+		"number of non-validators to initialize the testnet with")
+	cmd.Flags().StringVar(&b.outputDir, "o", "./mytestnet",
+		"directory to store initialization data for the testnet")
+	cmd.Flags().StringVar(&b.nodeDirPrefix, "node-dir-prefix", "node",
+		"prefix the directory name for each node with (node results in node0, node1, ...)")
+	cmd.Flags().Int64Var(&b.initialHeight, "initial-height", 0,
+		"initial height of the first block")
+
+	cmd.Flags().BoolVar(&b.populatePersistentPeers, "populate-persistent-peers", true,
+		"update config of each node with the list of persistent peers build using either"+
+			" hostname-prefix or"+
+			" starting-ip-address")
+	cmd.Flags().StringVar(&b.hostnamePrefix, "hostname-prefix", "node",
+		"hostname prefix (\"node\" results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
+	cmd.Flags().StringVar(&b.hostnameSuffix, "hostname-suffix", "",
+		"hostname suffix ("+
+			"\".xyz.com\""+
+			" results in persistent peers list ID0@node0.xyz.com:26656, ID1@node1.xyz.com:26656, ...)")
+	cmd.Flags().StringVar(&b.startingIPAddress, "starting-ip-address", "",
+		"starting IP address ("+
+			"\"192.168.0.1\""+
+			" results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
+	cmd.Flags().StringArrayVar(&b.hostnames, "hostname", []string{},
+		"manually override all hostnames of validators and non-validators (use --hostname multiple times for multiple hosts)")
+	cmd.Flags().IntVar(&b.p2pPort, "p2p-port", 26656,
+		"P2P Port")
+	cmd.Flags().BoolVar(&b.randomMonikers, "random-monikers", false,
+		"randomize the moniker for each generated node")
+
+	return &cmd
 }
 
-func testnetFiles(cmd *cobra.Command, args []string) error {
-	if len(hostnames) > 0 && len(hostnames) != (nValidators+nNonValidators) {
+func (b *builderTestnet) testnetFiles(cmd *cobra.Command, args []string) error {
+	if len(b.hostnames) > 0 && len(b.hostnames) != (b.nValidators+b.nNonValidators) {
 		return fmt.Errorf(
 			"testnet needs precisely %d hostnames (number of validators plus non-validators) if --hostname parameter is used",
-			nValidators+nNonValidators,
+			b.nValidators+b.nNonValidators,
 		)
 	}
 
 	config := cfg.DefaultConfig()
 
 	// overwrite default config if set and valid
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
+	if b.configFile != "" {
+		viper.SetConfigFile(b.configFile)
 		if err := viper.ReadInConfig(); err != nil {
 			return err
 		}
@@ -118,25 +126,25 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	genVals := make([]types.GenesisValidator, nValidators)
+	genVals := make([]types.GenesisValidator, b.nValidators)
 
-	for i := 0; i < nValidators; i++ {
-		nodeDirName := fmt.Sprintf("%s%d", nodeDirPrefix, i)
-		nodeDir := filepath.Join(outputDir, nodeDirName)
+	for i := 0; i < b.nValidators; i++ {
+		nodeDirName := fmt.Sprintf("%s%d", b.nodeDirPrefix, i)
+		nodeDir := filepath.Join(b.outputDir, nodeDirName)
 		config.SetRoot(nodeDir)
 
 		err := os.MkdirAll(filepath.Join(nodeDir, "config"), nodeDirPerm)
 		if err != nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(b.outputDir)
 			return err
 		}
 		err = os.MkdirAll(filepath.Join(nodeDir, "data"), nodeDirPerm)
 		if err != nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(b.outputDir)
 			return err
 		}
 
-		if err := initFilesWithConfig(config); err != nil {
+		if err := initFilesWithConfig(config, b.logger); err != nil {
 			return err
 		}
 
@@ -156,23 +164,23 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	for i := 0; i < nNonValidators; i++ {
-		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i+nValidators))
+	for i := 0; i < b.nNonValidators; i++ {
+		nodeDir := filepath.Join(b.outputDir, fmt.Sprintf("%s%d", b.nodeDirPrefix, i+b.nValidators))
 		config.SetRoot(nodeDir)
 
 		err := os.MkdirAll(filepath.Join(nodeDir, "config"), nodeDirPerm)
 		if err != nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(b.outputDir)
 			return err
 		}
 
 		err = os.MkdirAll(filepath.Join(nodeDir, "data"), nodeDirPerm)
 		if err != nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(b.outputDir)
 			return err
 		}
 
-		if err := initFilesWithConfig(config); err != nil {
+		if err := initFilesWithConfig(config, b.logger); err != nil {
 			return err
 		}
 	}
@@ -182,15 +190,15 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 		ChainID:         "chain-" + tmrand.Str(6),
 		ConsensusParams: types.DefaultConsensusParams(),
 		GenesisTime:     tmtime.Now(),
-		InitialHeight:   initialHeight,
+		InitialHeight:   b.initialHeight,
 		Validators:      genVals,
 	}
 
 	// Write genesis file.
-	for i := 0; i < nValidators+nNonValidators; i++ {
-		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
+	for i := 0; i < b.nValidators+b.nNonValidators; i++ {
+		nodeDir := filepath.Join(b.outputDir, fmt.Sprintf("%s%d", b.nodeDirPrefix, i))
 		if err := genDoc.SaveAs(filepath.Join(nodeDir, config.BaseConfig.Genesis)); err != nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(b.outputDir)
 			return err
 		}
 	}
@@ -200,43 +208,43 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 		persistentPeers string
 		err             error
 	)
-	if populatePersistentPeers {
-		persistentPeers, err = persistentPeersString(config)
+	if b.populatePersistentPeers {
+		persistentPeers, err = b.persistentPeersString(config)
 		if err != nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(b.outputDir)
 			return err
 		}
 	}
 
 	// Overwrite default config.
-	for i := 0; i < nValidators+nNonValidators; i++ {
-		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
+	for i := 0; i < b.nValidators+b.nNonValidators; i++ {
+		nodeDir := filepath.Join(b.outputDir, fmt.Sprintf("%s%d", b.nodeDirPrefix, i))
 		config.SetRoot(nodeDir)
 		config.P2P.AddrBookStrict = false
 		config.P2P.AllowDuplicateIP = true
-		if populatePersistentPeers {
+		if b.populatePersistentPeers {
 			config.P2P.PersistentPeers = persistentPeers
 		}
-		config.Moniker = moniker(i)
+		config.Moniker = b.moniker(i)
 
 		cfg.WriteConfigFile(filepath.Join(nodeDir, "config", "config.toml"), config)
 	}
 
-	fmt.Printf("Successfully initialized %v node directories\n", nValidators+nNonValidators)
+	fmt.Printf("Successfully initialized %v node directories\n", b.nValidators+b.nNonValidators)
 	return nil
 }
 
-func hostnameOrIP(i int) string {
-	if len(hostnames) > 0 && i < len(hostnames) {
-		return hostnames[i]
+func (b *builderTestnet) hostnameOrIP(i int) string {
+	if len(b.hostnames) > 0 && i < len(b.hostnames) {
+		return b.hostnames[i]
 	}
-	if startingIPAddress == "" {
-		return fmt.Sprintf("%s%d%s", hostnamePrefix, i, hostnameSuffix)
+	if b.startingIPAddress == "" {
+		return fmt.Sprintf("%s%d%s", b.hostnamePrefix, i, b.hostnameSuffix)
 	}
-	ip := net.ParseIP(startingIPAddress)
+	ip := net.ParseIP(b.startingIPAddress)
 	ip = ip.To4()
 	if ip == nil {
-		fmt.Printf("%v: non ipv4 address\n", startingIPAddress)
+		fmt.Printf("%v: non ipv4 address\n", b.startingIPAddress)
 		os.Exit(1)
 	}
 
@@ -246,29 +254,29 @@ func hostnameOrIP(i int) string {
 	return ip.String()
 }
 
-func persistentPeersString(config *cfg.Config) (string, error) {
-	persistentPeers := make([]string, nValidators+nNonValidators)
-	for i := 0; i < nValidators+nNonValidators; i++ {
-		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
+func (b *builderTestnet) persistentPeersString(config *cfg.Config) (string, error) {
+	persistentPeers := make([]string, b.nValidators+b.nNonValidators)
+	for i := 0; i < b.nValidators+b.nNonValidators; i++ {
+		nodeDir := filepath.Join(b.outputDir, fmt.Sprintf("%s%d", b.nodeDirPrefix, i))
 		config.SetRoot(nodeDir)
 		nodeKey, err := p2p.LoadNodeKey(config.NodeKeyFile())
 		if err != nil {
 			return "", err
 		}
-		persistentPeers[i] = p2p.IDAddressString(nodeKey.ID(), fmt.Sprintf("%s:%d", hostnameOrIP(i), p2pPort))
+		persistentPeers[i] = p2p.IDAddressString(nodeKey.ID(), fmt.Sprintf("%s:%d", b.hostnameOrIP(i), b.p2pPort))
 	}
 	return strings.Join(persistentPeers, ","), nil
 }
 
-func moniker(i int) string {
-	if randomMonikers {
+func (b *builderTestnet) moniker(i int) string {
+	if b.randomMonikers {
 		return randomMoniker()
 	}
-	if len(hostnames) > 0 && i < len(hostnames) {
-		return hostnames[i]
+	if len(b.hostnames) > 0 && i < len(b.hostnames) {
+		return b.hostnames[i]
 	}
-	if startingIPAddress == "" {
-		return fmt.Sprintf("%s%d%s", hostnamePrefix, i, hostnameSuffix)
+	if b.startingIPAddress == "" {
+		return fmt.Sprintf("%s%d%s", b.hostnamePrefix, i, b.hostnameSuffix)
 	}
 	return randomMoniker()
 }

--- a/cmd/tendermint/commands/version.go
+++ b/cmd/tendermint/commands/version.go
@@ -8,11 +8,14 @@ import (
 	"github.com/tendermint/tendermint/version"
 )
 
-// VersionCmd ...
-var VersionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show version info",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.TMCoreSemVer)
-	},
+const versionCmdName = "version"
+
+func (b *builderRoot) versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   versionCmdName,
+		Short: "Show version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.TMCoreSemVer)
+		},
+	}
 }

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -1,51 +1,11 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-
-	cmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
-	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
-	cfg "github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/libs/cli"
-	nm "github.com/tendermint/tendermint/node"
+	"github.com/tendermint/tendermint/cmd/tendermint/commands"
 )
 
 func main() {
-	rootCmd := cmd.RootCmd
-	rootCmd.AddCommand(
-		cmd.GenValidatorCmd,
-		cmd.InitFilesCmd,
-		cmd.ProbeUpnpCmd,
-		cmd.LightCmd,
-		cmd.ReplayCmd,
-		cmd.ReplayConsoleCmd,
-		cmd.ResetAllCmd,
-		cmd.ResetPrivValidatorCmd,
-		cmd.ShowValidatorCmd,
-		cmd.TestnetFilesCmd,
-		cmd.ShowNodeIDCmd,
-		cmd.GenNodeKeyCmd,
-		cmd.VersionCmd,
-		cmd.RollbackStateCmd,
-		debug.DebugCmd,
-		cli.NewCompletionCmd(rootCmd, true),
-	)
-
-	// NOTE:
-	// Users wishing to:
-	//	* Use an external signer for their validators
-	//	* Supply an in-proc abci app
-	//	* Supply a genesis doc file from another source
-	//	* Provide their own DB implementation
-	// can copy this file and use something other than the
-	// DefaultNewNode function
-	nodeFunc := nm.DefaultNewNode
-
-	// Create & start node
-	rootCmd.AddCommand(cmd.NewRunNodeCmd(nodeFunc))
-
-	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir)))
+	cmd := commands.Cmd()
 	if err := cmd.Execute(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
this is super helpful for running tests. ATM you can't run multiple
tests against a command, or multiple of the same commands to run multiple
executables. You're left calling out to the os.Exec to run the go installed
binary. This removes that burden allowing us to build as part of the test.

